### PR TITLE
Update three instances of 16.0.0.2 to 17.0.0.2 so we're using the lat…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,14 @@
 		<dependency>
 			<groupId>com.ibm.websphere.appserver.runtime</groupId>
 			<artifactId>wlp-webProfile7</artifactId>
-			<version>16.0.0.4</version>
+			<version>17.0.0.2</version>
 			<type>zip</type>
 		</dependency>
 
 		<dependency>
 			<groupId>net.wasdev.maven.tools.targets</groupId>
 			<artifactId>liberty-target</artifactId>
-			<version>16.0.0.4</version>
+			<version>17.0.0.2</version>
 			<type>pom</type>
 			<scope>provided</scope>
 		</dependency>
@@ -76,7 +76,7 @@
 					<assemblyArtifact>
 						<groupId>com.ibm.websphere.appserver.runtime</groupId>
 						<artifactId>wlp-webProfile7</artifactId>
-						<version>16.0.0.4</version>
+						<version>17.0.0.2</version>
 						<type>zip</type>
 					</assemblyArtifact>
 					<assemblyInstallDirectory>${project.build.directory}</assemblyInstallDirectory>


### PR DESCRIPTION
…est Liberty runtime.

(Typo in the PR and commit message: I updated from 16.0.0.4 to 17.0.0.2)